### PR TITLE
Multiple workers support for MongoDB ObjectId-based identifiers

### DIFF
--- a/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckSchedulerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckSchedulerTest.java
@@ -90,24 +90,33 @@ public class CheckSchedulerTest {
 
         mockChecksByObjectId = new ArrayList<Check>();
         
+        /* MongoDB ObjectId-based ids
+         * From http://docs.mongodb.org/manual/reference/object-id/
+         * Format is [Timestamp, 4 bytes (8 hex chars)][Machine identifier, 3 bytes][Process id, 2 bytes][randomized counter, 3 bytes]
+         * e.g. 000000001111112222333333
+         * where 0 is the timestamp portion, 1 is the machine identifier portion,
+         * 2 is the process id portion, 3 is the counter portion
+         * 
+         * After review, the timestamp portion gives the best work distribution for our data
+         */
         index1MockCheck = mock(Check.class);
-        when(index1MockCheck.getId()).thenReturn("012345678901234567890101");
+        when(index1MockCheck.getId()).thenReturn("000000010000000000000000");
         mockChecksByObjectId.add(index1MockCheck);
         
         index2MockCheck = mock(Check.class);
-        when(index2MockCheck.getId()).thenReturn("012345678901234567890102");
+        when(index2MockCheck.getId()).thenReturn("000000020000000000000000");
         mockChecksByObjectId.add(index2MockCheck);
         
         index3MockCheck = mock(Check.class);
-        when(index3MockCheck.getId()).thenReturn("012345678901234567890103");
+        when(index3MockCheck.getId()).thenReturn("000000030000000000000000");
         mockChecksByObjectId.add(index3MockCheck);
         
         index4MockCheck = mock(Check.class);
-        when(index4MockCheck.getId()).thenReturn("012345678901234567890104");
+        when(index4MockCheck.getId()).thenReturn("000000040000000000000000");
         mockChecksByObjectId.add(index4MockCheck);
 
         index5MockCheck = mock(Check.class);
-        when(index5MockCheck.getId()).thenReturn("012345678901234567890105");
+        when(index5MockCheck.getId()).thenReturn("000000050000000000000000");
         mockChecksByObjectId.add(index5MockCheck);
         
         SeyrenResponse<Check> checksByObjectId = new SeyrenResponse<Check>().withValues(mockChecksByObjectId);

--- a/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckSchedulerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckSchedulerTest.java
@@ -28,6 +28,7 @@ import com.seyren.core.domain.SeyrenResponse;
 public class CheckSchedulerTest {
     
     private ChecksStore mockChecksStore;
+    private ChecksStore mockChecksStoreByObjectId;
     private CheckRunnerFactory mockCheckRunnerFactory;
     private CheckRunner mockCheckRunner;
     private SeyrenConfig mockSeyrenConfig;
@@ -37,7 +38,13 @@ public class CheckSchedulerTest {
     private Check nearBeginningMockCheck;
     private Check justPastMiddleMockCheck;
     private Check at82PercentMockCheck;
-    
+    private List<Check> mockChecksByObjectId;
+    private Check index1MockCheck;
+    private Check index2MockCheck;
+    private Check index3MockCheck;
+    private Check index4MockCheck;
+    private Check index5MockCheck;
+
     @Before
     public void before() {
         mockChecksStore = mock(ChecksStore.class);
@@ -47,7 +54,7 @@ public class CheckSchedulerTest {
         
         when(mockSeyrenConfig.getNoOfThreads()).thenReturn(1);
         
-        // Mock checks        
+        // Mock checks for Guid-based id values 
         mockChecks = new ArrayList<Check>();
 
         // Mock check at beginning of range
@@ -77,6 +84,34 @@ public class CheckSchedulerTest {
         
         SeyrenResponse<Check> checks = new SeyrenResponse<Check>().withValues(mockChecks);
         when(mockChecksStore.getChecks(true, false)).thenReturn(checks);
+
+        // Mock checks for Mongo ObjectId-based id values
+        mockChecksStoreByObjectId = mock(ChecksStore.class);
+
+        mockChecksByObjectId = new ArrayList<Check>();
+        
+        index1MockCheck = mock(Check.class);
+        when(index1MockCheck.getId()).thenReturn("012345678901234567890101");
+        mockChecksByObjectId.add(index1MockCheck);
+        
+        index2MockCheck = mock(Check.class);
+        when(index2MockCheck.getId()).thenReturn("012345678901234567890102");
+        mockChecksByObjectId.add(index2MockCheck);
+        
+        index3MockCheck = mock(Check.class);
+        when(index3MockCheck.getId()).thenReturn("012345678901234567890103");
+        mockChecksByObjectId.add(index3MockCheck);
+        
+        index4MockCheck = mock(Check.class);
+        when(index4MockCheck.getId()).thenReturn("012345678901234567890104");
+        mockChecksByObjectId.add(index4MockCheck);
+
+        index5MockCheck = mock(Check.class);
+        when(index5MockCheck.getId()).thenReturn("012345678901234567890105");
+        mockChecksByObjectId.add(index5MockCheck);
+        
+        SeyrenResponse<Check> checksByObjectId = new SeyrenResponse<Check>().withValues(mockChecksByObjectId);
+        when(mockChecksStoreByObjectId.getChecks(true, false)).thenReturn(checksByObjectId);
     }
 
     @SuppressWarnings("unused")
@@ -170,5 +205,88 @@ public class CheckSchedulerTest {
         verify(mockCheckRunnerFactory, times(0)).create(nearBeginningMockCheck);
         verify(mockCheckRunnerFactory, times(0)).create(justPastMiddleMockCheck);
         verify(mockCheckRunnerFactory, times(1)).create(at82PercentMockCheck);
+    }
+
+    @Test
+    public void verifySingleWorkerExecutesAllChecks_ObjectIdBased() {
+        when(mockSeyrenConfig.getCheckExecutorInstanceIndex()).thenReturn(1);
+        when(mockSeyrenConfig.getCheckExecutorTotalInstances()).thenReturn(1);
+        
+        CheckScheduler checkScheduler = new CheckScheduler(
+        		mockChecksStoreByObjectId,
+        		mockCheckRunnerFactory,
+        		mockSeyrenConfig);
+
+        when(mockCheckRunnerFactory.create(index1MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index2MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index3MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index4MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index5MockCheck)).thenReturn(mockCheckRunner);
+        
+        checkScheduler.performChecks();
+        
+        verify(mockChecksStoreByObjectId, times(1)).getChecks(true, false);
+        verify(mockCheckRunnerFactory, times(1)).create(index1MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index2MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index3MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index4MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index5MockCheck);
+    }
+    
+    @Test
+    public void verifyFirstWorkerOfThreeGetsCorrectChecks_ObjectIdBased() {
+        when(mockSeyrenConfig.getCheckExecutorInstanceIndex()).thenReturn(1);
+        when(mockSeyrenConfig.getCheckExecutorTotalInstances()).thenReturn(3);
+        
+        CheckScheduler checkScheduler = new CheckScheduler(
+        		mockChecksStoreByObjectId,
+        		mockCheckRunnerFactory,
+        		mockSeyrenConfig);
+
+        when(mockCheckRunnerFactory.create(index1MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index2MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index3MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index4MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index5MockCheck)).thenReturn(mockCheckRunner);
+        
+        checkScheduler.performChecks();
+        
+        // With instance index of 1, should run any task whose characters, mod 3, equals 0
+        // 01 = 1, 02 = 2, 03 = 0, 04 = 1, 05 = 2, so worker 1 should run check 03
+        verify(mockChecksStoreByObjectId, times(1)).getChecks(true, false);
+        verify(mockCheckRunnerFactory, times(0)).create(index1MockCheck);
+        verify(mockCheckRunnerFactory, times(0)).create(index2MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index3MockCheck);
+        verify(mockCheckRunnerFactory, times(0)).create(index4MockCheck);
+        verify(mockCheckRunnerFactory, times(0)).create(index5MockCheck);
+    }
+
+    @Test
+    public void verifyThirdWorkerOfThreeGetsCorrectChecks_ObjectIdBased() {
+        when(mockSeyrenConfig.getCheckExecutorInstanceIndex()).thenReturn(3);
+        when(mockSeyrenConfig.getCheckExecutorTotalInstances()).thenReturn(3);
+        
+        CheckScheduler checkScheduler = new CheckScheduler(
+        		mockChecksStoreByObjectId,
+        		mockCheckRunnerFactory,
+        		mockSeyrenConfig);
+
+        when(mockCheckRunnerFactory.create(index1MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index2MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index3MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index4MockCheck)).thenReturn(mockCheckRunner);
+        when(mockCheckRunnerFactory.create(index5MockCheck)).thenReturn(mockCheckRunner);
+        
+        checkScheduler.performChecks();
+
+        // With instance index of 3, should run any task whose characters, mod 3, equals 2
+        // 01 = 1, 02 = 2, 03 = 0, 04 = 1, 05 = 2, so worker 3 should run checks 02 and 05
+        
+        verify(mockChecksStoreByObjectId, times(1)).getChecks(true, false);
+        verify(mockCheckRunnerFactory, times(0)).create(index1MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index2MockCheck);
+        verify(mockCheckRunnerFactory, times(0)).create(index3MockCheck);
+        verify(mockCheckRunnerFactory, times(0)).create(index4MockCheck);
+        verify(mockCheckRunnerFactory, times(1)).create(index5MockCheck);
     }
 }


### PR DESCRIPTION
For ids in the format of a MongoDB ObjectId, work sharding was not supported; previous version only supported Guids. Added support to shard work on both, based on id length (36 chars for Guids, 24 for ObjectIds).

Goal is to split work using existing data between multiple instances; MongoDB ObjectIds include two potential sources - a series of bits that are a timestamp (in seconds since epoch) and a series of bits that are a counter, initialized with a random value. Timestamp, based on real data, gave the best work distribution for 3 and 4 worker nodes and marginal performance for 5, while counter gave poor performance for 3 and 4 worker nodes and fair performance for 5 (refer to image below)
![work-distribution-2](https://cloud.githubusercontent.com/assets/14895254/10310445/db11ef7a-6bf6-11e5-9e1b-91ff4a688baa.png)
