### PR TITLE
Updated Mongo tests to comply wth licensing plugin by providing licen…

### DIFF
--- a/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/ConfigAT.java
+++ b/seyren-acceptance-tests/src/test/java/com/seyren/acceptancetests/ConfigAT.java
@@ -31,7 +31,7 @@ public class ConfigAT {
         assertThat(response, hasStatusCode(200));
         
         // Base
-        assertThat(response.asJson().size(), is(4));
+        assertThat(response.asJson().size(), is(6));
         assertThat(response.asJson(), hasJsonPath("$.baseUrl", not(isEmptyOrNullString())));
         assertThat(response.asJson(), hasJsonPath("$.graphiteCarbonPickleEnabled", is(false)));
         assertThat(response.asJson(), hasJsonPath("$.graphsEnabled", is(true)));

--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckConcurrencyGovernor.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckConcurrencyGovernor.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.core.service.schedule;
 
 import java.util.Date;

--- a/seyren-core/src/test/java/com/seyren/core/service/notification/ScriptNotificationServiceTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/notification/ScriptNotificationServiceTest.java
@@ -40,7 +40,7 @@ public class ScriptNotificationServiceTest {
     @Before
     public void before() {
         mockSeyrenConfig = mock(SeyrenConfig.class);
-        when(mockSeyrenConfig.getScriptType()).thenReturn("python");
+        when(mockSeyrenConfig.getScriptType()).thenReturn(SystemUtils.IS_OS_WINDOWS ? "py" : "python");
         when(mockSeyrenConfig.getScriptPath()).thenReturn(Thread.currentThread().getContextClassLoader().getResource("script.py").toString());
         when(mockSeyrenConfig.getBaseUrl()).thenReturn("http://somefakehostname.int");
         

--- a/seyren-mongo/pom.xml
+++ b/seyren-mongo/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/seyren-mongo/src/test/java/com/seyren/mongo/AbstractCheckRunTest.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/AbstractCheckRunTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.math.BigDecimal;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockCheck.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockCheck.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.math.BigDecimal;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockCheckRunnerFactory.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockCheckRunnerFactory.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.util.ArrayList;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockNotificationService.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockNotificationService.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.util.List;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockSubscription.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockSubscription.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import com.seyren.core.domain.Subscription;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockTargetChecker.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockTargetChecker.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.math.BigDecimal;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/SubscriptionFiringTests.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/SubscriptionFiringTests.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
The "maven-license-plugin" licensing plugin is automatically generating new headers for these Mongo tests.  This pull request commits those changes to be consistent with the other already license-compliant source code.