### PR TITLE
Add required licensing headers to new tests

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckConcurrencyGovernor.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckConcurrencyGovernor.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.core.service.schedule;
 
 import java.util.Date;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/AbstractCheckRunTest.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/AbstractCheckRunTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.math.BigDecimal;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockCheck.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockCheck.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.math.BigDecimal;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockCheckRunnerFactory.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockCheckRunnerFactory.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.util.ArrayList;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockNotificationService.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockNotificationService.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.util.List;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockSubscription.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockSubscription.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import com.seyren.core.domain.Subscription;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockTargetChecker.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockTargetChecker.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import java.math.BigDecimal;

--- a/seyren-mongo/src/test/java/com/seyren/mongo/SubscriptionFiringTests.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/SubscriptionFiringTests.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.seyren.mongo;
 
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
The license plugin is automatically adding the headers to these files.  Pushing changes permanently for easier merging.