### PR TITLE
Fixing consecutive checks bug and making graphite refresh rate configurable.

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunnerFactory.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckRunnerFactory.java
@@ -26,6 +26,7 @@ import com.seyren.core.service.checker.ValueChecker;
 import com.seyren.core.service.notification.NotificationService;
 import com.seyren.core.store.AlertsStore;
 import com.seyren.core.store.ChecksStore;
+import com.seyren.core.util.config.SeyrenConfig;
 
 @Named
 public class CheckRunnerFactory {
@@ -35,23 +36,25 @@ public class CheckRunnerFactory {
     private final TargetChecker targetChecker;
     private final ValueChecker valueChecker;
     private final Iterable<NotificationService> notificationServices;
+    private final SeyrenConfig seyrenConfig;
     
     @Inject
     public CheckRunnerFactory(AlertsStore alertsStore, ChecksStore checksStore, TargetChecker targetChecker, ValueChecker valueChecker,
-            List<NotificationService> notificationServices) {
+            List<NotificationService> notificationServices, SeyrenConfig seyrenConfig) {
         this.alertsStore = alertsStore;
         this.checksStore = checksStore;
         this.targetChecker = targetChecker;
         this.valueChecker = valueChecker;
         this.notificationServices = notificationServices;
+        this.seyrenConfig=seyrenConfig;
     }
 
     public CheckRunner create(Check check) {
-        return new CheckRunner(check, alertsStore, checksStore, targetChecker, valueChecker, notificationServices);
+        return new CheckRunner(check, alertsStore, checksStore, targetChecker, valueChecker, notificationServices, seyrenConfig.getGraphiteRefreshRate());
     }
 
     public CheckRunner create(Check check, BigDecimal value) {
-        return new CheckRunner(check, alertsStore, checksStore, new NoopTargetCheck(value), valueChecker, notificationServices);
+        return new CheckRunner(check, alertsStore, checksStore, new NoopTargetCheck(value), valueChecker, notificationServices, seyrenConfig.getGraphiteRefreshRate());
     }
 
 }

--- a/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
+++ b/seyren-core/src/main/java/com/seyren/core/service/schedule/CheckScheduler.java
@@ -62,7 +62,7 @@ public class CheckScheduler {
         this.checkExecutionTimeoutSeconds = seyrenConfig.getMaxCheckExecutionTimeInSeconds();
     }
     
-    @Scheduled(fixedRateString = "${GRAPHITE_REFRESH:60000}")
+    @Scheduled(fixedRateString = "${GRAPHITE_REFRESH}")
     public void performChecks() {
     	int checksInScope = 0;
     	int checksWereRun = 0;

--- a/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/config/SeyrenConfig.java
@@ -94,6 +94,7 @@ public class SeyrenConfig {
     private final String scriptPath;
     private final String scriptType;
     private final String scriptResourceUrls;
+    private final String graphiteRefreshRate;
     public SeyrenConfig() {
         
         // Base
@@ -118,6 +119,7 @@ public class SeyrenConfig {
         this.graphiteConnectTimeout = Integer.parseInt(configOrDefault("GRAPHITE_CONNECT_TIMEOUT", "0"));
         this.graphiteSocketTimeout = Integer.parseInt(configOrDefault("GRAPHITE_SOCKET_TIMEOUT", "0"));
         this.graphiteScheme = configOrDefault("GRAPHITE_SCHEME", "http");
+        this.graphiteRefreshRate = configOrDefault("GRAPHITE_REFRESH", "60000");
 
         // HTTP
 
@@ -502,8 +504,12 @@ public class SeyrenConfig {
         return scriptResourceUrls;
     }
 
+    @JsonIgnore
+    public String getGraphiteRefreshRate() {
+        return graphiteRefreshRate;
+    }
 
-  private static String configOrDefault(String propertyName, String defaultValue) {
+    private static String configOrDefault(String propertyName, String defaultValue) {
         return configOrDefault(list(propertyName), defaultValue);
     }
     

--- a/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckRunnerTest.java
+++ b/seyren-core/src/test/java/com/seyren/core/service/schedule/CheckRunnerTest.java
@@ -67,7 +67,7 @@ public class CheckRunnerTest {
                 mockChecksStore,
                 mockTargetChecker,
                 mockValueChecker,
-                mockNotificationServices);
+                mockNotificationServices, "60000");
         
         // Clear all cached values so that initial state is true even between tests
         CheckRunner.flushLastAlerts();

--- a/seyren-mongo/src/test/java/com/seyren/mongo/AbstractCheckRunTest.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/AbstractCheckRunTest.java
@@ -158,6 +158,6 @@ public abstract class AbstractCheckRunTest {
 		List<NotificationService> notificationServices = new ArrayList<NotificationService>();
 		notificationServices.add(this.notificationService);
 		runner = new CheckRunner(this.check, mongoStore, mongoStore, checker,  new DefaultValueChecker(),
-	            notificationServices);
+	            notificationServices, "60000");
 	}
 }

--- a/seyren-mongo/src/test/java/com/seyren/mongo/MockCheckRunnerFactory.java
+++ b/seyren-mongo/src/test/java/com/seyren/mongo/MockCheckRunnerFactory.java
@@ -9,15 +9,16 @@ import com.seyren.core.service.notification.NotificationService;
 import com.seyren.core.service.schedule.CheckRunnerFactory;
 import com.seyren.core.store.AlertsStore;
 import com.seyren.core.store.ChecksStore;
+import com.seyren.core.util.config.SeyrenConfig;
 import com.seyren.mongo.MongoStore;
 
 public class MockCheckRunnerFactory extends CheckRunnerFactory {
 
-	public MockCheckRunnerFactory(MongoStore mongoStore, 
-			TargetChecker targetChecker,
-			ValueChecker valueChecker, 
-			List<NotificationService>  notificationServices) {
-		super(mongoStore, mongoStore, targetChecker, valueChecker, notificationServices);
+	public MockCheckRunnerFactory(MongoStore mongoStore,
+								  TargetChecker targetChecker,
+								  ValueChecker valueChecker,
+								  List<NotificationService>  notificationServices, SeyrenConfig seyrenConfig) {
+		super(mongoStore, mongoStore, targetChecker, valueChecker, notificationServices, seyrenConfig);
 	}
 
 }

--- a/seyren-web/src/main/resources/security.properties
+++ b/seyren-web/src/main/resources/security.properties
@@ -7,3 +7,6 @@ authentication.service = mongo
 #LDAP Configuration Provider
 
 ldap.url = ldap://example.com
+
+#Time for Graphite Refresh in millliseconds
+GRAPHITE_REFRESH = 60000


### PR DESCRIPTION
1. Bug fix in Seyren: Seyren does not save alert when it's state is Ok->Ok i.e application is healthy.
Hence, while I was fetching "n" alerts for a check, I got old alerts as well. Adding a check that only alerts within with save time between my "Consecutive Checks" are taken into consideration.
2. Making graphite refresh job as configurable and adding key to property file. I am referring this key in Point 1.

Thanks,
Karan