### PR TITLE
the maxconnections is set to 20 making the 100 irrelevant

### DIFF
--- a/seyren-core/src/main/java/com/seyren/core/util/graphite/GraphiteHttpClient.java
+++ b/seyren-core/src/main/java/com/seyren/core/util/graphite/GraphiteHttpClient.java
@@ -72,6 +72,7 @@ public class GraphiteHttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphiteHttpClient.class);
     private static final String THRESHOLD_TARGET = "alias(dashed(color(constantLine(%s),\"%s\")),\"%s\")";
     private static final int MAX_CONNECTIONS_PER_ROUTE = 100;
+    private static final int MAX_CONNECTIONS = 300;
 
     private final JsonNodeResponseHandler jsonNodeHandler = new JsonNodeResponseHandler();
     private final ByteArrayResponseHandler chartBytesHandler = new ByteArrayResponseHandler();
@@ -258,6 +259,7 @@ public class GraphiteHttpClient {
         }
 
         manager.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_ROUTE);
+        manager.setMaxTotal(MAX_CONNECTIONS);
         return manager;
     }
 


### PR DESCRIPTION
This is an urgent fix for production. Ideally this would be set with a variable. 

```
--- BEFORE --- 
10/08/2018 23:22:32.914 [http-apr-8080-exec-6] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:32.961 [seyren.check-scheduler-41] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.030 [seyren.check-scheduler-18] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.037 [seyren.check-scheduler-14] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.156 [seyren.check-scheduler-97] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.170 [seyren.check-scheduler-43] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.305 [seyren.check-scheduler-19] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.341 [seyren.check-scheduler-81] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.438 [seyren.check-scheduler-94] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.515 [seyren.check-scheduler-66] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.526 [seyren.check-scheduler-54] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.595 [seyren.check-scheduler-52] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]
10/08/2018 23:22:33.610 [seyren.check-scheduler-99] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 0; route allocated: 20 of 100; total allocated: 20 of 20]

--- AFTER --- 
10/08/2018 23:40:31.318 [http-apr-8080-exec-22] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection released: [id: 103][route: {s}->https://graphite.bigdata.expedia.com:443][total kept alive: 43; route allocated: 2 of 100; total allocated: 102 of 300]
10/08/2018 23:40:31.347 [seyren.check-scheduler-79] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection [id: 88][route: {s}->https://graphite.prod.monitoring.expedia.com:443] can be kept alive indefinitely
10/08/2018 23:40:31.351 [seyren.check-scheduler-32] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection request: [route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 43; route allocated: 100 of 100; total allocated: 102 of 300]
10/08/2018 23:40:31.358 [seyren.check-scheduler-58] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection [id: 67][route: {s}->https://graphite.prod.monitoring.expedia.com:443] can be kept alive indefinitely
10/08/2018 23:40:31.360 [seyren.check-scheduler-11] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection [id: 63][route: {s}->https://graphite.prod.monitoring.expedia.com:443] can be kept alive indefinitely
10/08/2018 23:40:31.361 [seyren.check-scheduler-79] DEBUG  o.a.h.i.c.PoolingHttpClientConnectionManager - Connection released: [id: 88][route: {s}->https://graphite.prod.monitoring.expedia.com:443][total kept alive: 44; route allocated: 100 of 100; total allocated: 102 of 300]
```